### PR TITLE
Option to choose between sending each items value as payload on its own topic or all items as JSON payload

### DIFF
--- a/_config_.py
+++ b/_config_.py
@@ -9,6 +9,7 @@ _MQTT_user = ''			                # Mqtt User name
 _MQTT_pass = ''			                # Mqtt password
 _MQTT_TOPIC_SUB = 'SUBmcz'			    # Publish command messages here
 _MQTT_TOPIC_PUB = 'PUBmcz'			    # Information messages by daemon are published here
+_MQTT_PAYLOAD_TYPE = 'TOPIC'            # Payload as seperate subtopic (_MQTT_PAYLOAD_TYPE='TOPIC') or as JSON (_MQTT_PAYLOAD_TYPE='JSON'), default is JSON
 _MCZip ='192.168.120.1'				    # Stove IP Address. This probably is always this address.
 _MCZport = '81'						    # Port du serveur embarqué du poele
 _VERSION = '1.0'					    # Version

--- a/install
+++ b/install
@@ -16,6 +16,7 @@ if [ ! -d "/opt/maestro/" ];then
 	chmod -R 0755 /opt/maestro/
 fi
 
+cp _config_.py /opt/maestro
 cp command.py /opt/maestro
 cp messages.py /opt/maestro
 cp maestro.py /opt/maestro

--- a/install_daemon
+++ b/install_daemon
@@ -18,7 +18,7 @@ if [ ! -d "/opt/maestro/" ];then
 fi
 
 cp _config_.py /opt/maestro
-cp commands.py /opt/maestro
+cp command.py /opt/maestro
 cp messages.py /opt/maestro
 cp maestro.py /opt/maestro
 

--- a/maestro.py
+++ b/maestro.py
@@ -138,7 +138,7 @@ def on_message(ws, message):
     if message_array[0] == MaestroMessageType.Info.value:
         process_info_message(message)
     else:
-        logger.info('Unsupported message type recieved !')
+        logger.info('Unsupported message type received !')
 
 def on_error(ws, error):
     logger.info(error)

--- a/maestro.py
+++ b/maestro.py
@@ -14,6 +14,7 @@ from _config_ import _MQTT_user
 from _config_ import _MQTT_authentication
 from _config_ import _MQTT_TOPIC_PUB
 from _config_ import _MQTT_TOPIC_SUB
+from _config_ import _MQTT_PAYLOAD_TYPE
 from _config_ import _MQTT_port
 from _config_ import _MQTT_ip
 from commands import MaestroCommand, get_maestro_command, maestrocommandvalue_to_websocket_string, MaestroCommandValue


### PR DESCRIPTION
This pull request introduces a _config_ option _MQTT_PAYLOAD_TYPE and the according changes to the code.
Reason for the change is that its sometimes easier to have distinct messages instead of a bulk in JSON.
The default behaviour of the code will stay as is if this option has any value other than 'TOPIC'.
If the config option is set to 'TOPIC' then messages arent sent as JSON anymore.
Instead the attribute name becomes a subtopic and the attribute value becomes the payload of an mqtt-message.