### PR TITLE
Feature/systemservice

### DIFF
--- a/install
+++ b/install
@@ -17,7 +17,7 @@ if [ ! -d "/opt/maestro/" ];then
 fi
 
 cp _config_.py /opt/maestro
-cp command.py /opt/maestro
+cp commands.py /opt/maestro
 cp messages.py /opt/maestro
 cp maestro.py /opt/maestro
 

--- a/install
+++ b/install
@@ -1,24 +1,36 @@
 #!/bin/sh
 
 if [ $(whoami) != 'root' ]; then
-	echo -e "\nVous devez avoir les droits super-utilisateur pour executer $0"
-	exit 1;
+        echo -e "\nVous devez avoir les droits super-utilisateur pour executer $0"
+        exit 1;
+fi
+
+# Check Python 3 is installed
+if [[ ! $(which python3) ]]; then
+        echo "Python 3 is required"
+        exit 1
 fi
 
 echo "Installation des dépendances"
-pip3 install paho-mqtt
-pip3 install websocket-client
+apt-get update
+apt-get install build-essential \
+    libsystemd-dev \
+    python-systemd
+/usr/bin/python3 -m pip install paho-mqtt
+/usr/bin/python3 -m pip install websocket-client
+/usr/bin/python3 -m pip install systemd-python
+/usr/bin/python3 -m pip install psutil
 
 echo "Copie des fichiers necessaires"
-if [ ! -d "/opt/maestro/" ];then
-	mkdir /opt/maestro/
-	chown -R $USER /opt/maestro/
-	chmod -R 0755 /opt/maestro/
+if [ ! -d "/usr/local/lib/maestro_service/" ];then
+        mkdir /usr/local/lib/maestro_service/
+        chown -R maestro_service /usr/local/lib/maestro_service/
+        chmod -R 0755 /usr/local/lib/maestro_service/
 fi
 
-cp _config_.py /opt/maestro
-cp commands.py /opt/maestro
-cp messages.py /opt/maestro
-cp maestro.py /opt/maestro
+cp _config_.py /usr/local/lib/maestro_service
+cp commands.py /usr/local/lib/maestro_service
+cp messages.py /usr/local/lib/maestro_service
+cp maestro.py /usr/local/lib/maestro_service
 
-python3 /opt/maestro/maestro.py
+python3 /usr/local/lib/maestro_service/maestro.py

--- a/install_daemon
+++ b/install_daemon
@@ -1,26 +1,58 @@
 #!/bin/sh
 
 if [ $(whoami) != 'root' ]; then
-	echo -e "\nVous devez avoir les droits super-utilisateur pour executer $0"
-	exit 1;
+        echo -e "\nInsuffiecent Rights. (Vous devez avoir les droits super-utilisateur pour executer $0)"
+        exit 1;
 fi
 
+# Check Python 3 is installed
+if [[ ! $(which python3) ]]; then
+        echo "Python 3 is required"
+        exit 1
+fi
 echo "Installation des dépendances"
-pip install paho-mqtt
-pip install websocket-client
-echo "Copie des fichiers necessaires"
-if [ ! -d "/opt/maestro/" ];then
-	mkdir /opt/maestro/
-	chown -R $USER /opt/maestro/
-	chmod -R 0755 /opt/maestro/
+apt-get update
+apt-get install build-essential \
+    libsystemd-dev
+/usr/bin/python3 -m pip install paho-mqtt
+/usr/bin/python3 -m pip install websocket-client
+/usr/bin/python3 -m pip install systemd-python
+/usr/bin/python3 -m pip install psutil
+
+echo "Creating service user"
+SERVICE_USER='maestro_service'
+SERVICE_GROUP='maestro_service'
+
+if [[ $(grep -q "^${SERVICE_GROUP}:" /etc/group) ]]; then
+        groupadd $SERVICE_GROUP
 fi
 
-cp _config_.py /opt/maestro
-cp commands.py /opt/maestro
-cp messages.py /opt/maestro
-cp maestro.py /opt/maestro
+if [[ ! $(id -u $SERVICE_USER) ]]; then
+        useradd -r -s /bin/false maestro_service
+        usermod -g $SERVIC_GROUP $SERVICE_USER
+fi
+
+echo "Stopping service (Arret du service maestro)"
+systemctl stop maestro.service
+
+echo "Copy files. (Copie des fichiers necessaires)"
+if [ ! -d "/usr/local/lib/maestro_service" ];then
+        mkdir -p /usr/local/lib/maestro_service
+        chown -R $SERVICE_USER:$SERVICE_GROUP /usr/local/lib/maestro_service
+fi
+
+cp _config_.py /usr/local/lib/maestro_service
+cp commands.py /usr/local/lib/maestro_service
+cp messages.py /usr/local/lib/maestro_service
+cp maestro.py /usr/local/lib/maestro_service
+
+if [ ! -d "/usr/local/lib/maestro_service" ];then
+        chown -R $SERVICE_USER:$SERVICE_GROUP /usr/local/lib/maestro_service/*
+        chmod -R 0755 /usr/local/lib/maestro_service/*
+fi
 
 cp maestro.service /etc/systemd/system
-chmod a+x /etc/systemd/system/maestro.service
+chmod a-x /etc/systemd/system/maestro.service
 systemctl --system daemon-reload
+systemctl enable maestro.service
 echo "Fin de l'installation, tapez sudo systemctl start maestro.service pour lancer le daemon" 

--- a/install_daemon
+++ b/install_daemon
@@ -6,8 +6,6 @@ if [ $(whoami) != 'root' ]; then
 fi
 
 echo "Installation des dépendances"
-pip3 install paho-mqtt
-pip3 install websocket-client
 pip install paho-mqtt
 pip install websocket-client
 echo "Copie des fichiers necessaires"
@@ -18,7 +16,7 @@ if [ ! -d "/opt/maestro/" ];then
 fi
 
 cp _config_.py /opt/maestro
-cp command.py /opt/maestro
+cp commands.py /opt/maestro
 cp messages.py /opt/maestro
 cp maestro.py /opt/maestro
 

--- a/maestro.service
+++ b/maestro.service
@@ -1,14 +1,18 @@
 [Unit]
 Description=MCZ Maestro Equipment Gateway with MQTT Server
 After=network.target
-ConditionPathExists=/opt/maestro
+StartLimitIntervalSec=0
+ConditionPathExists=/usr/local/lib/maestro_service
 [Service]
-Type=forking
-ExecStart=/usr/bin/python '/opt/maestro/maestro.py'
+Environment=PYTHONUNBUFFERED=1
+Type=notify
+User=maestro_service
+Group=maestro_service
+ExecStart=/usr/bin/python3 /usr/local/lib/maestro_service/maestro.py
 TimeoutSec=0
 StandardOutput=tty
 RemainAfterExit=yes
-SysVStartPriority=99
 Restart=always
+RestartSec=3
 [Install]
 WantedBy=multi-user.target

--- a/update_daemon
+++ b/update_daemon
@@ -5,19 +5,54 @@ if [ $(whoami) != 'root' ]; then
 	exit 1;
 fi
 
+# Check Python 3 is installed
+if [[ ! $(which python3) ]]; then
+        echo "Python 3 is required"
+        exit 1
+fi
+
+echo "Creating service user"
+SERVICE_USER='maestro_service'
+SERVICE_GROUP='maestro_service'
+
+id -g $SERVICE_GROUP >& /dev/null
+if [ $? -eq 1 ]; then
+	groupadd $SERVICE_GROUP
+fi
+
+id -u $SERVICE_USER >& /dev/null
+if [ $? -eq 1 ]; then
+	useradd -r -s /bin/false maestro_service
+	usermod -g $SERVIC_GROUP $SERVICE_USER
+fi
+
 echo "Stopping service (Arret du service maestro)"
 systemctl stop maestro.service
 
+echo "Installation des dépendances"
+apt-get update
+apt-get install build-essential \
+    libsystemd-dev
+/usr/bin/python3 -m pip install paho-mqtt
+/usr/bin/python3 -m pip install websocket-client
+/usr/bin/python3 -m pip install systemd-python
+/usr/bin/python3 -m pip install psutil
+
 echo "Copy files. (Copie des fichiers necessaires)"
-if [ ! -d "/opt/maestro/" ];then
-	mkdir /opt/maestro/
-	chown -R $USER /opt/maestro/
-	chmod -R 0755 /opt/maestro/
+if [ ! -d "/usr/local/lib/maestro_service" ];then
+	mkdir -p /usr/local/lib/maestro_service
+	chown -R root:$SERVICE_GROUP /usr/local/lib/maestro_service
 fi
 
-cp commands.py /opt/maestro
-cp messages.py /opt/maestro
-cp maestro.py /opt/maestro
+cp _config_.py /usr/local/lib/maestro_service
+cp commands.py /usr/local/lib/maestro_service
+cp messages.py /usr/local/lib/maestro_service
+cp maestro.py /usr/local/lib/maestro_service
+
+if [ -d "/usr/local/lib/maestro_service" ];then
+	chown -R root:$SERVICE_GROUP /usr/local/lib/maestro_service/*
+	chmod -R 0744 /usr/local/lib/maestro_service/*
+fi
 
 cp maestro.service /etc/systemd/system
 chmod a+x /etc/systemd/system/maestro.service


### PR DESCRIPTION
## Improving the installation of the script as system service.
Currently the service expects the maestro.py to fork itself and exit but it doesn't. This is causing that calling _sudo systemctl start maestro.service_ doesn't return to command line.
The service itself is running as user root with all the privilegues belonging to root which isn't a good idea in terms of security.
Logging is done to a logfile though a service should better log to the system journal.

### Changes in this pull request:
- Changes service Type to notify (forking of the process is then handled by systemd).
- Adds a notify to the maestro.py script.
- Chages service to run as user/group maestro_service
- Adds imports needed for systemd handling.
- Changes logging to journal if run as system service.
- Adds a check for the availability of Python 3
- Install and update scripts install additional needed dependencies
- Location of service files moved from /opt/maestro to /usr/local/lib/maestro_service
- Creates a user and group maestro_service 
- Removes the executable from the maestro.service file.

### Todo
- Investigate if forking would be a better solution (see https://code.activestate.com/recipes/278731-creating-a-daemon-the-python-way/)