### PR TITLE
adds a new command to set the date and time

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -3,6 +3,7 @@
 MCZ Maestro Command class
 These are the supported commands to be set via websocket
 '''
+from datetime import datetime, timedelta
 
 class MaestroCommand(object):
     """Maestro Command. Consists of a readable name., a websocket ID and a command type."""
@@ -36,6 +37,7 @@ MAESTRO_COMMANDS.append(MaestroCommand('Sound_Effects', 50, 'onoff'))
 MAESTRO_COMMANDS.append(MaestroCommand('Power', 34, 'onoff40'))
 MAESTRO_COMMANDS.append(MaestroCommand('Fan_State', 37, 'int'))# 0, 1, 2, 3 ,4,  5 ,6
 MAESTRO_COMMANDS.append(MaestroCommand('Control_Mode', 40, 'onoff')) # 0 = Auto , 1 = Manual
+MAESTRO_COMMANDS.append(MaestroCommand('Set_DateTime', 0, 'datetime')) # Format ddmmYYYYHHMM
 # Untested, proceed with caution
 MAESTRO_COMMANDS.append(MaestroCommand('Feeding_Screw', 34, '49')) # 49 as parameter to socket for feeding screw activiation
 MAESTRO_COMMANDS.append(MaestroCommand('Celsius_Fahrenheit', 49, 'int'))
@@ -64,6 +66,13 @@ def maestrocommandvalue_to_websocket_string(maestrocommandval):
     maestrocommand = maestrocommandval.command
     if maestrocommand.name == "GetInfo":
         write = "C|RecuperoInfo"
+    elif maestrocommand.name == "Set_DateTime":
+        try:
+            # Check if value is a valid date else exception is thrown
+            datetime.strptime(maestrocommandval.value, "%d%m%Y%H%M")
+            write = "C|SalvaDataOra|" + str(maestrocommandval.value)
+        except:
+            pass
     else:
         write = "C|WriteParametri|"
         writevalue = float(maestrocommandval.value)

--- a/messages.py
+++ b/messages.py
@@ -16,6 +16,7 @@ class MaestroMessageType(Enum):
     WifiSonde = "0B"
     DatabaseName = "0D"
     SoftwareVersion = "0E"
+    StringData = "AA"
     Ping = "PING"
 
 class MaestroInformation(object):
@@ -87,10 +88,11 @@ MAESTRO_INFORMATION.append(MaestroInformation(57, "SetBoiler", 'int'))
 MAESTRO_INFORMATION.append(MaestroInformation(58, "SetHealth", 'int'))  # != 255 == Hydro version
 MAESTRO_INFORMATION.append(MaestroInformation(59, "Return_Temperature", 'temperature'))
 MAESTRO_INFORMATION.append(MaestroInformation(60, "AntiFreeze", 'onoff'))
+MAESTRO_INFORMATION.append(MaestroInformation(61, "SaveDateTime", 'datetime'))
 
 def get_maestro_info(frameid):
     """Return Maestro info from the commandlist by name"""
-    if frameid >= 0 and frameid <= 60:
+    if frameid >= 0 and frameid <= 61:
         return MAESTRO_INFORMATION[frameid]
     else:
         return MaestroInformation(frameid, 'Unknown' + str(frameid), 'int')


### PR DESCRIPTION
The oven's time runs ahead or past the actual time after a while and has to be set.
The pull request adds a new command Set_DateTime with which the date and time of the MCZ oven can be set.
The value to the command has to be given as string in the format
"ddmmYYYYHHmm", e.g. "171220201636" for the date 17/12/2020 04:36 pm.