### PR TITLE
A new command Set_DateTime with which the date and time of the

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -4,6 +4,8 @@ MCZ Maestro Command class
 These are the supported commands to be set via websocket
 '''
 
+from datetime import datetime
+
 class MaestroCommand(object):
     """Maestro Command. Consists of a readable name., a websocket ID and a command type."""
     def __init__(self, name, id, commandtype, commandcategory):
@@ -64,6 +66,9 @@ MAESTRO_COMMANDS.append(MaestroCommand('DuctedFan2', 7, 'percentage', 'Diagnosti
 MAESTRO_COMMANDS.append(MaestroCommand('Pump_PWM', 8, 'percentage', 'Diagnostics'))
 MAESTRO_COMMANDS.append(MaestroCommand('3wayvalve', 9, 'onoff', 'Diagnostics'))
 
+# Datetime commands
+MAESTRO_COMMANDS.append(MaestroCommand('Set_DateTime', 0, 'datetime', 'SetDateTime')) # The value to the command has to be given as string in the format - > "ddmmYYYYHHmm", e.g. "171220201636" for the date 17/12/2020 04:36 pm.
+
 def get_maestro_command(commandname):
     """Return Maestro command from the command list by name"""
     i = 0
@@ -78,7 +83,18 @@ def maestrocommandvalue_to_websocket_string(maestrocommandval):
     write = ""
     maestrocommand = maestrocommandval.command
     if maestrocommand.commandcategory == "GetInfo":
-        write = "C|RecuperoInfo"           
+        write = "C|RecuperoInfo"      
+    elif maestrocommand.commandcategory == "SetDateTime":
+        try:
+            if (maestrocommandval.value == "NOW"):
+                now = datetime.now()
+                write = "C|SalvaDataOra|" + str(now.strftime("%d%m%Y%H%M"))
+            else:    
+                # Check if value is a valid date else exception is thrown
+                datetime.strptime(maestrocommandval.value, "%d%m%Y%H%M")
+                write = "C|SalvaDataOra|" + str(maestrocommandval.value)
+        except:
+            pass     
     else:
         if maestrocommand.commandcategory == "Diagnostics":
             write = "C|Diagnostica|"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,18 @@
-version: '3.3'
+version: "3.3"
 services:
-
   maestrogateway:
     image: chibald/maestrogateway:latest
     network_mode: host
-    environment:      
-      MQTT_ip: 'broker.hivemq.com'
+    environment:
+      MQTT_ip: "broker.hivemq.com"
       MQTT_port: 1883
-      MQTT_authentication: 'False'
-      MQTT_user: ''
-      MQTT_pass: ''
-      MQTT_TOPIC_SUB: 'Maestro/Command/'
-      MQTT_TOPIC_PUB: 'Maestro/'
-      MQTT_PAYLOAD_TYPE: 'TOPIC'
+      MQTT_authentication: "False"
+      MQTT_user: ""
+      MQTT_pass: ""
+      MQTT_TOPIC_SUB: "Maestro/Command/"
+      MQTT_TOPIC_PUB: "Maestro/"
+      MQTT_PAYLOAD_TYPE: "TOPIC"
       WS_RECONNECTS_BEFORE_ALERT: 5
-      MCZip: '192.168.120.1'
-      MCZport: '81'
+      MCZip: "192.168.120.1"
+      MCZport: "81"
+      TZ: "Europe/Amsterdam"

--- a/maestro.py
+++ b/maestro.py
@@ -187,6 +187,8 @@ def on_message(ws, message):
     message_array = message.split("|")
     if message_array[0] == MaestroMessageType.Info.value:
         process_info_message(message)
+    elif message_array[0] == MaestroMessageType.StringData.value:
+        logger.info('Date Time Set ' + str(message_array[1]))
     else:
         logger.info('Unsupported message type received !')
 
@@ -208,9 +210,13 @@ def on_open(ws):
         for i in range(360*4):
             time.sleep(0.25)
             while not CommandQueue.empty():
-                cmd = maestrocommandvalue_to_websocket_string(CommandQueue.get())
-                logger.info("Websocket: Send " + str(cmd))
-                ws.send(cmd)        
+                command = CommandQueue.get()
+                cmd = maestrocommandvalue_to_websocket_string(command)
+                if cmd != "":
+                    logger.info("Websocket: Send " + str(cmd))
+                    ws.send(cmd)
+                else:
+                    logger.error(f"Invalid command: {command.name} Value: {command.value}")
         logger.info('Closing Websocket Connection')
         ws.close()
     thread.start_new_thread(run, ())

--- a/messages.py
+++ b/messages.py
@@ -16,6 +16,7 @@ class MaestroMessageType(Enum):
     WifiSonde = "0B"
     DatabaseName = "0D"
     SoftwareVersion = "0E"
+    StringData = "AA"
     Ping = "PING"
 
 


### PR DESCRIPTION
The oven's time runs ahead or past the actual time after a while and has to be set.
The pull request adds a new command Set_DateTime with which the date and time of the MCZ oven can be set.
The value to the command has to be given as string in the format
"ddmmYYYYHHmm", e.g. "171220201636" for the date 17/12/2020 04:36 pm.

This was taken from tharts' PR: 
#21